### PR TITLE
Replace Sass imports with module usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.parcel-cache
+dist
+.DS_Store

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,9 +1,9 @@
-@import 'blocks/page';
-@import 'blocks/header';
-@import 'blocks/top-bar';
-@import 'blocks/icon';
-@import 'blocks/menu';
-@import 'blocks/nav';
+@use './blocks/page';
+@use './blocks/header';
+@use './blocks/top-bar';
+@use './blocks/icon';
+@use './blocks/menu';
+@use './blocks/nav';
 
 /* #region footer */
 .footer {


### PR DESCRIPTION
## Summary
- replace deprecated Sass `@import` statements with modern `@use` module references to remove build warnings
- add a `.gitignore` to exclude build artifacts and dependencies from version control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d96df8f7fc8325bfc2b03d2d2b0049